### PR TITLE
Updated offset for static attributes

### DIFF
--- a/tf2attributes.sp
+++ b/tf2attributes.sp
@@ -281,8 +281,8 @@ public Native_IsIntegerValue(Handle:plugin, numParams)
 stock GetStaticAttribs(Address:pItemDef, iAttribIndices[], iAttribValues[], size = 16)
 {
 	if (!IsValidAddress(pItemDef)) return 0;	//...-1 maybe?
-	new iNumAttribs = LoadFromAddress(pItemDef + Address:32, NumberType_Int32);
-	new Address:pAttribList = Address:LoadFromAddress(pItemDef + Address:20, NumberType_Int32);
+	new iNumAttribs = LoadFromAddress(pItemDef + Address:40, NumberType_Int32);
+	new Address:pAttribList = Address:LoadFromAddress(pItemDef + Address:44, NumberType_Int32);
 	for (new i = 0; i < iNumAttribs && i < size; i++)	//THIS IS HOW YOU GET THE ATTRIBUTES ON AN ITEMDEF!
 	{
 		iAttribIndices[i] = LoadFromAddress(pAttribList + Address:(i * 8), NumberType_Int16);

--- a/tf2attributes.sp
+++ b/tf2attributes.sp
@@ -281,8 +281,8 @@ public Native_IsIntegerValue(Handle:plugin, numParams)
 stock GetStaticAttribs(Address:pItemDef, iAttribIndices[], iAttribValues[], size = 16)
 {
 	if (!IsValidAddress(pItemDef)) return 0;	//...-1 maybe?
-	new iNumAttribs = LoadFromAddress(pItemDef + Address:40, NumberType_Int32);
-	new Address:pAttribList = Address:LoadFromAddress(pItemDef + Address:44, NumberType_Int32);
+	new iNumAttribs = LoadFromAddress(pItemDef + Address:0x28, NumberType_Int32);
+	new Address:pAttribList = Address:LoadFromAddress(pItemDef + Address:0x1C, NumberType_Int32);
 	for (new i = 0; i < iNumAttribs && i < size; i++)	//THIS IS HOW YOU GET THE ATTRIBUTES ON AN ITEMDEF!
 	{
 		iAttribIndices[i] = LoadFromAddress(pAttribList + Address:(i * 8), NumberType_Int16);


### PR DESCRIPTION
I noticed that the offset for CUtlVector\<CEconItemAttributeDefinition\> from CTFItemDefinition changed. I do not use this plugin so test these changes. See image below for new memory layout. Hope this saves some time!


![static_attributes](https://user-images.githubusercontent.com/8845238/31858369-fa90f7d2-b6c3-11e7-9581-4fee8b4b1a82.png)
