### PR TITLE
Set SetNTVOptional to void and comment out unused code

### DIFF
--- a/tf2attributes.inc
+++ b/tf2attributes.inc
@@ -223,7 +223,7 @@ public SharedPlugin __pl_tf2attributes =
 };
 
 #if !defined REQUIRE_PLUGIN
-public __pl_tf2attributes_SetNTVOptional()
+public void __pl_tf2attributes_SetNTVOptional()
 {
 	MarkNativeAsOptional("TF2Attrib_SetByName");
 	MarkNativeAsOptional("TF2Attrib_SetByDefIndex");

--- a/tf2attributes.inc
+++ b/tf2attributes.inc
@@ -246,10 +246,10 @@ public void __pl_tf2attributes_SetNTVOptional()
 	MarkNativeAsOptional("TF2Attrib_IsIntegerValue");
 	MarkNativeAsOptional("TF2Attrib_IsReady");
 
-	MarkNativeAsOptional("TF2Attrib_SetInitialValue");
-	MarkNativeAsOptional("TF2Attrib_GetInitialValue");
-	MarkNativeAsOptional("TF2Attrib_SetIsSetBonus");
-	MarkNativeAsOptional("TF2Attrib_GetIsSetBonus");
+//	MarkNativeAsOptional("TF2Attrib_SetInitialValue");
+//	MarkNativeAsOptional("TF2Attrib_GetInitialValue");
+//	MarkNativeAsOptional("TF2Attrib_SetIsSetBonus");
+//	MarkNativeAsOptional("TF2Attrib_GetIsSetBonus");
 }
 #endif
 


### PR DESCRIPTION
SetNTVOptional missing void type.

Commented out MarkNativeAsOptional for functions that are no longer supported.