### PR TITLE
Add HookValue natives

### DIFF
--- a/tf2.attributes.txt
+++ b/tf2.attributes.txt
@@ -77,6 +77,22 @@
 				"linux"				"@_ZN14CAttributeList20DestroyAllAttributesEv"
 				"mac"				"@_ZN14CAttributeList20DestroyAllAttributesEv"
 			}
+			"CAttributeManager::AttribHookValue<float>"
+			{
+				// (float value, string_t attrClass, CBaseEntity* ent, CUtlVector<CBaseEntity*> *reentrant, bool const_str)
+				// called in unique x-ref to "ubercharge_ammo" on Windows
+				"library"			"server"
+				"linux"				"@_ZN17CAttributeManager15AttribHookValueIfEET_S1_PKcPK11CBaseEntityP10CUtlVectorIPS4_10CUtlMemoryIS8_iEEb"
+				"windows"			"\x55\x8B\xEC\x83\xEC\x0C\x8B\x0D\x2A\x2A\x2A\x2A\x53\x56\x57\x33\xF6\x33\xFF\x89\x75\xF4\x89\x7D\xF8\x8B\x41\x08\x85\xC0\x74\x2A\x68\x2A\x2A\x2A\x2A\x68\x2A\x2A\x2A\x2A\x68\x2A\x2A\x2A\x2A\x68\x2A\x2A\x2A\x2A\x6A\x6B"
+			}
+			"CAttributeManager::AttribHookValue<int>"
+			{
+				// (int value, string_t attrClass, CBaseEntity* ent, CUtlVector<CBaseEntity*> *reentrant, bool const_str)
+				// called in unique x-ref to "mod_max_primary_clip_override" on Windows
+				"library"			"server"
+				"linux"				"@_ZN17CAttributeManager15AttribHookValueIiEET_S1_PKcPK11CBaseEntityP10CUtlVectorIPS4_10CUtlMemoryIS8_iEEb"
+				"windows"			"\x55\x8B\xEC\x83\xEC\x10\x8B\x0D\x2A\x2A\x2A\x2A\x53\x56\x57\x33\xFF\x33\xDB\x89\x7D\xF0\x89\x5D\xF4\x8B\x41\x08\x85\xC0\x74\x2A\x68\x2A\x2A\x2A\x2A\x68\x2A\x2A\x2A\x2A\x68\x2A\x2A\x2A\x2A\x68\x2A\x2A\x2A\x2A\x6A\x6B"
+			}
 		}
 	}
 }

--- a/tf2attributes.inc
+++ b/tf2attributes.inc
@@ -203,6 +203,28 @@ native int TF2Attrib_GetSOCAttribs(int iEntity, int[] iAttribIndices, float[] fl
 native bool TF2Attrib_IsIntegerValue(int iDefIndex);
 
 /**
+ * Applies a transformation to the given initial value, following the rules according to the given attribute class.
+ * 
+ * @param flInitial			Initial float value.
+ * @param attrClass			The attribute class, as from the "attribute_class" key in items_game.
+ * @param iEntity			The entity that should be checked.  Checking players also checks their equipped items.
+ * 
+ * @return					Transformed initial value.
+ */
+native float TF2Attrib_HookValueFloat(float flInitial, const char[] attrClass, int iEntity);
+
+/**
+ * Applies a transformation to the given initial value, following the rules according to the given attribute class.
+ * 
+ * @param iInitial			Initial float value.
+ * @param attrClass			The attribute class, as from the "attribute_class" key in items_game.
+ * @param iEntity			The entity that should be checked.  Checking players also checks their equipped items.
+ * 
+ * @return					Transformed initial value.
+ */
+native int TF2Attrib_HookValueInt(int nInitial, const char[] attrClass, int iEntity);
+
+/**
  * Gets whether the plugin loaded without ANY errors.
  * For the purpose of allowing dependencies to ignore the plugin if this returns false.
  * Check in OnAllPluginsLoaded() or something. I dunno.


### PR DESCRIPTION
Backported from my upstream fork; it's been in production use for a while.

These allow SourceMod plugins to transform values based on attribute classes in the same way the game does it; plugin authors don't have to implement rules based on calling GetValue for multiple names and multiple entities.

Example usage to determine airblast cost:
```
int iAmmoUse = TF2Attrib_HookValueInt(FindConVar("tf_flamethrower_burstammo").IntValue, "mult_airblast_cost", weapon);
```