### PR TITLE
Add CustomPlayerAttribute natives

### DIFF
--- a/tf2.attributes.txt
+++ b/tf2.attributes.txt
@@ -77,6 +77,21 @@
 				"linux"				"@_ZN14CAttributeList20DestroyAllAttributesEv"
 				"mac"				"@_ZN14CAttributeList20DestroyAllAttributesEv"
 			}
+			"CTFPlayer::AddCustomAttribute" //(const char*, float, float), returns void
+			{
+				"library"			"server"
+				"windows"			"\x55\x8B\xEC\xF3\x0F\x10\x4D\x10\x83\xEC\x10"
+				"linux"				"@_ZN9CTFPlayer18AddCustomAttributeEPKcff"
+				"mac"				"@_ZN9CTFPlayer18AddCustomAttributeEPKcff"
+			}
+			"CTFPlayer::RemoveCustomAttribute" //(const char*), returns void
+			{
+				// called with x-ref string "hidden maxhealth non buffed"
+				"library"			"server"
+				"windows"			"\x55\x8B\xEC\x83\xEC\x10\x53\x56\x57\xFF\x75\x08"
+				"linux"				"@_ZN9CTFPlayer21RemoveCustomAttributeEPKc"
+				"mac"				"@_ZN9CTFPlayer21RemoveCustomAttributeEPKc"
+			}
 		}
 	}
 }

--- a/tf2attributes.inc
+++ b/tf2attributes.inc
@@ -203,6 +203,28 @@ native int TF2Attrib_GetSOCAttribs(int iEntity, int[] iAttribIndices, float[] fl
 native bool TF2Attrib_IsIntegerValue(int iDefIndex);
 
 /**
+ * Adds a custom, potentially temporary attribute to a player.
+ * 
+ * @param client			Client index to set the attribute on.
+ * @param strAttrib			Name of the attribute, as from the "name" key in items_game.
+ * @param flValue			Value to set m_flValue to.
+ * @param flDuration		Duration of the attribute.  If less than 0, the attribute will not be automatically removed.
+ * 
+ * @noreturn
+ */
+native void TF2Attrib_AddCustomPlayerAttribute(int client, const char[] strAttrib, float flValue, float flDuration = -1.0);
+
+/**
+ * Removes a previously applied custom attribute on a player.
+ *
+ * @param client			Client index to remove the attribute from.
+ * @param strAttrib			Name of the attribute, as from the "name" key in items_game.
+ *
+ * @noreturn
+ */
+native void TF2Attrib_RemoveCustomPlayerAttribute(int client, const char[] strAttrib);
+
+/**
  * Gets whether the plugin loaded without ANY errors.
  * For the purpose of allowing dependencies to ignore the plugin if this returns false.
  * Check in OnAllPluginsLoaded() or something. I dunno.
@@ -244,6 +266,9 @@ public void __pl_tf2attributes_SetNTVOptional()
 	MarkNativeAsOptional("TF2Attrib_GetSOCAttribs");
 	MarkNativeAsOptional("TF2Attrib_ListDefIndices");
 	MarkNativeAsOptional("TF2Attrib_IsIntegerValue");
+	MarkNativeAsOptional("TF2Attrib_AddCustomPlayerAttribute");
+	MarkNativeAsOptional("TF2Attrib_RemoveCustomPlayerAttribute");
+	
 	MarkNativeAsOptional("TF2Attrib_IsReady");
 
 //	MarkNativeAsOptional("TF2Attrib_SetInitialValue");


### PR DESCRIPTION
The other thing from my upstream that isn't massive refactoring work.

Allows SourceMod plugins to add attributes by definition name to the player, with an optional duration.  Doesn't do error checking on invalid attribute names.

```
// Adds 50.0 max health for 30 seconds (what the Dalokoh's does internally)
TF2Attrib_AddCustomPlayerAttribute(client, "hidden maxhealth non buffed", 50.0, 30.0);
```