### PR TITLE
Fix plugin not loading on Linux

### DIFF
--- a/gamedata/tf2.attributes.txt
+++ b/gamedata/tf2.attributes.txt
@@ -157,7 +157,9 @@
 			// user-facing error messages so we stop getting badgered about "Could not initialize call to CEconItemSchema::GetItemDefinition"
 			"PluginFailMessage"
 			{
+				"windows"			""
 				"windows64"			"This plugin is currently not supported on 64-bit servers.  See https://github.com/FlaminSarge/tf2attributes/issues/50 and make sure you are NOT launching the server with srcds_win64 / tf_win64."
+				"linux"				""
 				"linux64"			"This plugin is currently not supported on 64-bit servers.  See https://github.com/FlaminSarge/tf2attributes/issues/50 and make sure you are NOT launching the server with srcds_run_64."
 				"mac"				"This plugin is no longer supported on Mac."
 				"mac64"				"This plugin is no longer supported on Mac.  Especially not on the nonexistent 64-bit version of SRCDS."

--- a/scripting/tf2attributes.sp
+++ b/scripting/tf2attributes.sp
@@ -130,7 +130,7 @@ public void OnPluginStart() {
 	
 	char pluginFailMessage[256];
 	if (GameConfGetKeyValue(hGameConf, "PluginFailMessage", pluginFailMessage,
-			sizeof(pluginFailMessage))) {
+			sizeof(pluginFailMessage)) && pluginFailMessage[0]) {
 		SetFailState(pluginFailMessage);
 	}
 	


### PR DESCRIPTION
After upgrading to plugin version 1.7.4, our Linux server started to report that "This plugin is no longer supported on Mac.".

Turns out Linux actually falls back to the "mac" key if it can't find a "linux" key. As to why that is, I do not know.

If you want to keep the messages, this is probably the sanest solution. Otherwise ditch the mac keys entirely. Can mac even still run srcds?